### PR TITLE
Ignore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-11, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
 
     - name: Build binaries
       run: dotnet fsi ./src/make_release.fsx build
@@ -40,7 +40,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
 
     - uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
 
     - name: Restore dependencies
       run: dotnet restore

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 _A command-line utility to hash directories and files._
 
-**hashdir** aims to be the easiest way to hash a file/directory. This is useful in many situations such as transferring files, archiving data, or detecting duplicates. It is a single binary, works on all major OS's, and has a simple command-line interface. It is developed with F# on .NET 6.
+**hashdir** aims to be the easiest way to hash a file/directory. This is useful in many situations such as transferring files, archiving data, or detecting duplicates. It is a single binary, works on all major OS's, and has a simple command-line interface. It is developed with F# on .NET 7.
 
 Links: [Github](https://github.com/ultimateanu/hashdir), [NuGet](https://www.nuget.org/packages/hashdir), [Project Site](https://ultimateanu.github.io/hashdir)
 
@@ -25,7 +25,7 @@ There are several ways to get hashdir. Full details can be found [here](https://
 ## Usage
 ```
 hashdir:
-  A command-line utility to checksum directories and files.
+  A command-line utility to hash directories and files.
 
 Usage:
   hashdir [options] [<item>...] [command]
@@ -38,6 +38,7 @@ Options:
   -s, --save                                                   Save the checksum to a file
   -i, --include-hidden-files                                   Include hidden files
   -e, --skip-empty-dir                                         Skip empty directories
+  -n, --ignore <pattern>                                       Directories/files to not include
   -h, --hash-only                                              Print only the hash
   -a, --algorithm <md5|ripemd160|sha1|sha256|sha384|sha512>    The hash function to use [default: sha1]
   -c, --color                                                  Colorize the output [default: True]

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Commands:
 1. Hash a file/directory: `hashdir ~/Desktop/project/`
 2. Hash a directory with hidden files and print tree: `hashdir --include-hidden-files --tree ~/Desktop/project`
 3. Hash multiple items using MD5: `hashdir -a md5 song.mp3 info.txt report.pdf`
+4. Hash a directory, but ignore certain directories/files: `hashdir --ignore "node_modules" --ignore "**/*.xml" ~/Desktop/project`
 
 ## License
 [MIT License](https://github.com/ultimateanu/hashdir/blob/main/LICENSE)

--- a/src/App.Tests/App.Tests.fsproj
+++ b/src/App.Tests/App.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>

--- a/src/App.Tests/AppTests.fs
+++ b/src/App.Tests/AppTests.fs
@@ -31,7 +31,7 @@ type AppTests(output: ITestOutputHelper) =
         Assert.Equal(HashType.MD5, rootOpt.Algorithm)
 
         let expectedStr =
-            "RootOpt[Items:[|\"report.pdf\"; \"sources.txt\"|] PrintTree:true Save:true IncludeHiddenFiles:true SkipEmptyDir:false Ignore:[|\"**/node\"; \"cache.txt\"|] HashOnly:false Algorithm:MD5 Color:false]"
+            "RootOpt[Items:[|\"report.pdf\"; \"sources.txt\"|] PrintTree:true Save:true IncludeHiddenFiles:true SkipEmptyDir:false IgnorePatterns:[|\"**/node\"; \"cache.txt\"|] HashOnly:false Algorithm:MD5 Color:false]"
 
         Assert.Equal(expectedStr, rootOpt.ToString())
 
@@ -53,7 +53,7 @@ type AppTests(output: ITestOutputHelper) =
         Assert.Equal(PrintVerbosity.Detailed, checkOpt.Verbosity)
 
         let expectedStr =
-            "CheckOpt[Items:[|\"report.pdf\"|] IncludeHiddenFiles:false SkipEmptyDir:true Ignore:[|\"**/node\"; \"cache.txt\"|] Algorithm:Some SHA256 Color:true]"
+            "CheckOpt[Items:[|\"report.pdf\"|] IncludeHiddenFiles:false SkipEmptyDir:true IgnorePatterns:[|\"**/node\"; \"cache.txt\"|] Algorithm:Some SHA256 Color:true]"
 
         Assert.Equal(expectedStr, checkOpt.ToString())
 

--- a/src/App.Tests/AppTests.fs
+++ b/src/App.Tests/AppTests.fs
@@ -22,6 +22,7 @@ type AppTests(output: ITestOutputHelper) =
                 true,
                 true,
                 false,
+                [| "**/node"; "cache.txt" |], (* ignore *)
                 false,
                 "md5",
                 false
@@ -30,7 +31,7 @@ type AppTests(output: ITestOutputHelper) =
         Assert.Equal(HashType.MD5, rootOpt.Algorithm)
 
         let expectedStr =
-            "RootOpt[Items:[|\"report.pdf\"; \"sources.txt\"|] PrintTree:true Save:true IncludeHiddenFiles:true SkipEmptyDir:false HashOnly:false Algorithm:MD5 Color:false]"
+            "RootOpt[Items:[|\"report.pdf\"; \"sources.txt\"|] PrintTree:true Save:true IncludeHiddenFiles:true SkipEmptyDir:false Ignore:[|\"**/node\"; \"cache.txt\"|] HashOnly:false Algorithm:MD5 Color:false]"
 
         Assert.Equal(expectedStr, rootOpt.ToString())
 
@@ -41,6 +42,7 @@ type AppTests(output: ITestOutputHelper) =
                 [| "report.pdf" |],
                 false,
                 true,
+                [| "**/node"; "cache.txt" |], (* ignore *)
                 "sha256",
                 "detailed",
                 true
@@ -51,7 +53,7 @@ type AppTests(output: ITestOutputHelper) =
         Assert.Equal(PrintVerbosity.Detailed, checkOpt.Verbosity)
 
         let expectedStr =
-            "CheckOpt[Items:[|\"report.pdf\"|] IncludeHiddenFiles:false SkipEmptyDir:true Algorithm:Some SHA256 Color:true]"
+            "CheckOpt[Items:[|\"report.pdf\"|] IncludeHiddenFiles:false SkipEmptyDir:true Ignore:[|\"**/node\"; \"cache.txt\"|] Algorithm:Some SHA256 Color:true]"
 
         Assert.Equal(expectedStr, checkOpt.ToString())
 
@@ -62,6 +64,7 @@ type AppTests(output: ITestOutputHelper) =
                 [| "report.pdf" |],
                 false,
                 true,
+                [||], (* ignore *)
                 null,
                 "detailed",
                 true

--- a/src/App.Tests/E2ETests.fs
+++ b/src/App.Tests/E2ETests.fs
@@ -11,24 +11,35 @@ open Xunit.Abstractions
 [<AbstractClass>]
 type BaseTestData() =
     abstract member data: seq<obj[]>
+
     interface IEnumerable<obj[]> with
-        member this.GetEnumerator() : IEnumerator<obj[]> = this.data.GetEnumerator()
-        member this.GetEnumerator() : IEnumerator = this.data.GetEnumerator() :> IEnumerator
+        member this.GetEnumerator() : IEnumerator<obj[]> =
+            this.data.GetEnumerator()
+
+        member this.GetEnumerator() : IEnumerator =
+            this.data.GetEnumerator() :> IEnumerator
 
 type HashingConfigs() =
     inherit BaseTestData()
-    override _.data = Seq.ofList [
-        [| box [||] |];
-        [| box [|"--algorithm"; "md5"|] |];
-        [| box [|"--include-hidden-files"|] |];
-        [| box [|"--skip-empty-dir"|] |];
-        [| box [|"--skip-empty-dir"; "--include-hidden-files"|] |];
-    ]
+
+    override _.data =
+        Seq.ofList
+            [ [| box [||] |]
+              [| box [| "--algorithm"; "md5" |] |]
+              [| box [| "--include-hidden-files" |] |]
+              [| box [| "--skip-empty-dir" |] |]
+              [| box [| "--skip-empty-dir"; "--include-hidden-files" |] |] ]
 
 type FsTempDirSetupFixture() =
     // Single temp dir which always gets cleaned up.
     let tempDir =
-        Path.GetFullPath(Path.Combine(Path.GetTempPath(), "hashdir_test_" + Guid.NewGuid().ToString()))
+        Path.GetFullPath(
+            Path.Combine(
+                Path.GetTempPath(),
+                "hashdir_test_" + Guid.NewGuid().ToString()
+            )
+        )
+
     let projectDir = Path.Combine(tempDir, "project")
     let topFileA = Path.Combine(tempDir, "topA.txt")
 
@@ -58,6 +69,7 @@ type FsTempDirSetupFixture() =
         Directory.CreateDirectory(Path.Combine(projectDir, "c")) |> ignore
         let hiddenFilePath = Path.Combine(projectDir, "c", ".c1.txt")
         File.WriteAllText(hiddenFilePath, "c1")
+
         if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
             File.SetAttributes(hiddenFilePath, FileAttributes.Hidden)
 
@@ -74,11 +86,18 @@ type FsTempDirSetupFixture() =
     member _.TopFileA = topFileA
 
 
-type FsTests(fsTempDirSetupFixture: FsTempDirSetupFixture, debugOutput: ITestOutputHelper) =
-    let hashFile = Path.Combine(fsTempDirSetupFixture.TempDir, "project_hash.sha1.txt")
+type FsTests
+    (
+        fsTempDirSetupFixture: FsTempDirSetupFixture,
+        debugOutput: ITestOutputHelper
+    ) =
+    let hashFile =
+        Path.Combine(fsTempDirSetupFixture.TempDir, "project_hash.sha1.txt")
+
     let oldStdOut = Console.Out
     let customStdOut = new IO.StringWriter()
-    let getStdOut() =
+
+    let getStdOut () =
         let buf = customStdOut.GetStringBuilder().ToString()
         customStdOut.GetStringBuilder().Clear() |> ignore
         buf
@@ -101,76 +120,105 @@ type FsTests(fsTempDirSetupFixture: FsTempDirSetupFixture, debugOutput: ITestOut
     [<Fact>]
     member _.``help flag``() =
         // Run program with help flag.
-        let returnCode = Program.main [|"--help"|]
+        let returnCode = Program.main [| "--help" |]
         Assert.Equal(0, returnCode)
 
         // Expect output to have help info.
         Assert.Contains(
-            "A command-line utility to checksum directories and files.",
-            getStdOut())
+            "A command-line utility to hash directories and files.",
+            getStdOut ()
+        )
 
 
     [<Fact>]
     member _.``check hash file``() =
         // Simple hashfile with sha1 hash for project dir.
-        File.WriteAllText(hashFile, "264aba9860d3dc213423759991dad98259bbf0c5  /project")
+        File.WriteAllText(
+            hashFile,
+            "264aba9860d3dc213423759991dad98259bbf0c5  /project"
+        )
 
         // Run program and ask to check the hashfile.
-        let returnCode = Program.main [|"check"; hashFile; "-a"; "sha1"|]
+        let returnCode = Program.main [| "check"; hashFile; "-a"; "sha1" |]
         Assert.Equal(0, returnCode)
 
         // Expect output to say matches.
         let expectedOutput = sprintf "MATCHES    /project%s" Environment.NewLine
-        Assert.Equal(expectedOutput, getStdOut())
+        Assert.Equal(expectedOutput, getStdOut ())
 
     [<Fact>]
     member _.``check hash file (include hidden files)``() =
         // Simple hashfile with sha1 hash for project dir (including hidden files).
-        File.WriteAllText(hashFile, "ea60ecdab5f999ef34fd19825ce63fac83a0c75b  /project")
+        File.WriteAllText(
+            hashFile,
+            "ea60ecdab5f999ef34fd19825ce63fac83a0c75b  /project"
+        )
 
         // Run program and ask to check the hashfile.
-        let returnCode = Program.main [|"check"; hashFile; "-a"; "sha1"; "--include-hidden-files"|]
+        let returnCode =
+            Program.main
+                [| "check"; hashFile; "-a"; "sha1"; "--include-hidden-files" |]
+
         Assert.Equal(0, returnCode)
 
         // Expect output to say matches.
         let expectedOutput = sprintf "MATCHES    /project%s" Environment.NewLine
-        Assert.Equal(expectedOutput, getStdOut())
+        Assert.Equal(expectedOutput, getStdOut ())
 
     [<Fact>]
     member _.``check hash file (skip empty dir)``() =
         // Simple hashfile with sha1 hash for project dir (including empty dirs).
-        File.WriteAllText(hashFile, "d4efa40abcb6ec73ee83df4c532aad568e7160a5  /project")
+        File.WriteAllText(
+            hashFile,
+            "d4efa40abcb6ec73ee83df4c532aad568e7160a5  /project"
+        )
 
         // Run program and ask to check the hashfile.
-        let returnCode = Program.main [|"check"; hashFile; "-a"; "sha1"; "--skip-empty-dir"|]
+        let returnCode =
+            Program.main
+                [| "check"; hashFile; "-a"; "sha1"; "--skip-empty-dir" |]
+
         Assert.Equal(0, returnCode)
 
         // Expect output to say matches.
         let expectedOutput = sprintf "MATCHES    /project%s" Environment.NewLine
-        Assert.Equal(expectedOutput, getStdOut())
+        Assert.Equal(expectedOutput, getStdOut ())
 
     [<Fact>]
     member _.``check hash file (include hidden files, skip empty dir)``() =
         // Simple hashfile with sha1 hash for project dir (including empty dirs).
-        File.WriteAllText(hashFile, "16e6570418dba2f4589c8972b9cfe4bb9e5c449c  /project")
+        File.WriteAllText(
+            hashFile,
+            "16e6570418dba2f4589c8972b9cfe4bb9e5c449c  /project"
+        )
 
         // Run program and ask to check the hashfile.
-        let returnCode = Program.main [|"check"; hashFile; "-a"; "sha1"; "--include-hidden-files"; "--skip-empty-dir"|]
+        let returnCode =
+            Program.main
+                [| "check"
+                   hashFile
+                   "-a"
+                   "sha1"
+                   "--include-hidden-files"
+                   "--skip-empty-dir" |]
+
         Assert.Equal(0, returnCode)
 
         // Expect output to say matches.
         let expectedOutput = sprintf "MATCHES    /project%s" Environment.NewLine
-        Assert.Equal(expectedOutput, getStdOut())
+        Assert.Equal(expectedOutput, getStdOut ())
 
     [<Theory>]
     [<ClassData(typeof<HashingConfigs>)>]
     member _.``check hash file matches hashing output``(inputFlags) =
-        let hashingArgs = Array.append [|fsTempDirSetupFixture.ProjectDir|] inputFlags
-        let checkArgs = Array.append [|"check"; hashFile|] inputFlags
+        let hashingArgs =
+            Array.append [| fsTempDirSetupFixture.ProjectDir |] inputFlags
+
+        let checkArgs = Array.append [| "check"; hashFile |] inputFlags
 
         // Write output of hashing to hashFile.
         Assert.Equal(0, Program.main hashingArgs)
-        File.WriteAllText(hashFile, getStdOut())
+        File.WriteAllText(hashFile, getStdOut ())
 
         // Run program and ask to check the hashfile.
         let returnCode = Program.main checkArgs
@@ -178,51 +226,79 @@ type FsTests(fsTempDirSetupFixture: FsTempDirSetupFixture, debugOutput: ITestOut
 
         // Expect output to say matches.
         let expectedOutput = sprintf "MATCHES    /project%s" Environment.NewLine
-        Assert.Equal(expectedOutput, getStdOut())
+        Assert.Equal(expectedOutput, getStdOut ())
 
     [<Fact>]
     member _.``check auto detects md5``() =
         // Write output of hashing (md5) to hashFile.
-        Assert.Equal(0, Program.main [|fsTempDirSetupFixture.ProjectDir; "-a"; "md5"|])
-        File.WriteAllText(hashFile, getStdOut())
+        Assert.Equal(
+            0,
+            Program.main [| fsTempDirSetupFixture.ProjectDir; "-a"; "md5" |]
+        )
+
+        File.WriteAllText(hashFile, getStdOut ())
 
         // Run program and ask to check the hashfile without specifying algorithm.
-        let returnCode = Program.main [|"check"; hashFile|]
+        let returnCode = Program.main [| "check"; hashFile |]
 
         // Expect output to say matches.
         let expectedOutput = sprintf "MATCHES    /project%s" Environment.NewLine
-        Assert.Equal(expectedOutput, getStdOut())
+        Assert.Equal(expectedOutput, getStdOut ())
         Assert.Equal(0, returnCode)
 
     [<Theory>]
     [<InlineData("normal",
-        "MATCHES    match.txt",
-        "DIFFERS    diff.txt",
-        "ERROR")>]
+                 "MATCHES    match.txt",
+                 "DIFFERS    diff.txt",
+                 "ERROR")>]
     [<InlineData("detailed",
-        "MATCHES    match.txt (ef5c844eab88bcaca779bd2f3ad67b573bbbbfca)",
-        "DIFFERS    diff.txt (75a0ee1ba911f2f5199177dfd31808a12511bbdc, expected: 1111570418dba2f4589c8972b9cfe4bb9e5caaaa)",
-        "missing.txt is not a valid path")>]
+                 "MATCHES    match.txt (ef5c844eab88bcaca779bd2f3ad67b573bbbbfca)",
+                 "DIFFERS    diff.txt (75a0ee1ba911f2f5199177dfd31808a12511bbdc, expected: 1111570418dba2f4589c8972b9cfe4bb9e5caaaa)",
+                 "missing.txt is not a valid path")>]
     [<InlineData("quiet", "", "", "")>]
-    member _.``check hash file different verbosity levels``(verbosityLevel, matchOutput, diffOutput, errorOutput) =
+    member _.``check hash file different verbosity levels``
+        (
+            verbosityLevel,
+            matchOutput,
+            diffOutput,
+            errorOutput
+        ) =
         // Setup to ensure 1 match, diff and missing result.
-        File.WriteAllText(Path.Combine(fsTempDirSetupFixture.TempDir, "match.txt"), "match")
-        File.WriteAllText(Path.Combine(fsTempDirSetupFixture.TempDir, "diff.txt"), "diff")
-        let hashFileContent = "\
+        File.WriteAllText(
+            Path.Combine(fsTempDirSetupFixture.TempDir, "match.txt"),
+            "match"
+        )
+
+        File.WriteAllText(
+            Path.Combine(fsTempDirSetupFixture.TempDir, "diff.txt"),
+            "diff"
+        )
+
+        let hashFileContent =
+            "\
             ef5c844eab88bcaca779bd2f3ad67b573bbbbfca  match.txt\n\
             1111570418dba2f4589c8972b9cfe4bb9e5caaaa  diff.txt\n\
             1111570418dba2f4589c8972b9cfe4bb9e5caaaa  missing.txt"
+
         File.WriteAllText(hashFile, hashFileContent)
 
         // Run program and ask to check the hashfile.
-        let returnCode = Program.main [|"check"; hashFile; "-a"; "sha1"; "--verbosity"; verbosityLevel|]
+        let returnCode =
+            Program.main
+                [| "check"
+                   hashFile
+                   "-a"
+                   "sha1"
+                   "--verbosity"
+                   verbosityLevel |]
 
         // Expect return code 1 (for missing hash item) and result messages.
         Assert.Equal(2, returnCode)
-        let checkOutput = getStdOut()
+        let checkOutput = getStdOut ()
         Assert.Contains(matchOutput, checkOutput)
         Assert.Contains(diffOutput, checkOutput)
         Assert.Contains(errorOutput, checkOutput)
+
         if verbosityLevel = "quiet" then
             Assert.Equal("", checkOutput)
 
@@ -232,33 +308,50 @@ type FsTests(fsTempDirSetupFixture: FsTempDirSetupFixture, debugOutput: ITestOut
         let nonExistHashFile = hashFile + "z"
 
         // Run program and ask to check the hashfile.
-        let returnCode = Program.main [|"check"; nonExistHashFile|]
+        let returnCode = Program.main [| "check"; nonExistHashFile |]
 
         // Expect return code 1 (for missing input) and error message.
         Assert.Equal(1, returnCode)
+
         let expectedOutput =
-            sprintf "Error: '%s' is not a valid hash file%s"
+            sprintf
+                "Error: '%s' is not a valid hash file%s"
                 nonExistHashFile
                 Environment.NewLine
-        Assert.Equal(expectedOutput, getStdOut())
+
+        Assert.Equal(expectedOutput, getStdOut ())
 
     [<Fact>]
     member _.``save hash files correctly``() =
         // Run hashdir and save hash file.
-        let returnCode = Program.main [|fsTempDirSetupFixture.TopFileA;
-            fsTempDirSetupFixture.ProjectDir; "--save"|]
+        let returnCode =
+            Program.main
+                [| fsTempDirSetupFixture.TopFileA
+                   fsTempDirSetupFixture.ProjectDir
+                   "--save" |]
+
         Assert.Equal(0, returnCode)
 
         // Expect saved hash files with correct hash.
-        let projectHashFile = Path.Join(fsTempDirSetupFixture.TempDir, "project.1.sha1.txt")
-        Assert.True(File.Exists(projectHashFile))
-        Assert.Equal("264aba9860d3dc213423759991dad98259bbf0c5  /project\n",
-            File.ReadAllText(projectHashFile))
+        let projectHashFile =
+            Path.Join(fsTempDirSetupFixture.TempDir, "project.1.sha1.txt")
 
-        let topAHashFile = Path.Join(fsTempDirSetupFixture.TempDir, "topA.txt.1.sha1.txt")
+        Assert.True(File.Exists(projectHashFile))
+
+        Assert.Equal(
+            "264aba9860d3dc213423759991dad98259bbf0c5  /project\n",
+            File.ReadAllText(projectHashFile)
+        )
+
+        let topAHashFile =
+            Path.Join(fsTempDirSetupFixture.TempDir, "topA.txt.1.sha1.txt")
+
         Assert.True(File.Exists(topAHashFile))
-        Assert.Equal("80c7fac7855e00074c94782d5d85076981be0115  topA.txt\n",
-            File.ReadAllText(topAHashFile))
+
+        Assert.Equal(
+            "80c7fac7855e00074c94782d5d85076981be0115  topA.txt\n",
+            File.ReadAllText(topAHashFile)
+        )
 
         // Cleanup
         File.Delete(projectHashFile)
@@ -267,14 +360,17 @@ type FsTests(fsTempDirSetupFixture: FsTempDirSetupFixture, debugOutput: ITestOut
     [<Fact>]
     member _.``save hash files with correct id``() =
         let getHashFilePath id =
-            Path.Join(fsTempDirSetupFixture.TempDir, sprintf "topA.txt.%s.sha1.txt" (id.ToString()))
+            Path.Join(
+                fsTempDirSetupFixture.TempDir,
+                sprintf "topA.txt.%s.sha1.txt" (id.ToString())
+            )
 
         // Run hashdir multiple times.
-        Program.main [|fsTempDirSetupFixture.TopFileA; "--save"|] |> ignore
-        Program.main [|fsTempDirSetupFixture.TopFileA; "--save"|] |> ignore
+        Program.main [| fsTempDirSetupFixture.TopFileA; "--save" |] |> ignore
+        Program.main [| fsTempDirSetupFixture.TopFileA; "--save" |] |> ignore
         File.WriteAllText(getHashFilePath 42, "something")
         File.WriteAllText(getHashFilePath "xyz", "something")
-        Program.main [|fsTempDirSetupFixture.TopFileA; "--save"|] |> ignore
+        Program.main [| fsTempDirSetupFixture.TopFileA; "--save" |] |> ignore
 
         // Expect multiple hash files with correct id.
         Assert.True(File.Exists(getHashFilePath 1))

--- a/src/App.Tests/E2ETests.fs
+++ b/src/App.Tests/E2ETests.fs
@@ -26,6 +26,7 @@ type HashingConfigs() =
         Seq.ofList
             [ [| box [||] |]
               [| box [| "--algorithm"; "md5" |] |]
+              [| box [| "--ignore"; "**/a1.txt" |] |]
               [| box [| "--include-hidden-files" |] |]
               [| box [| "--skip-empty-dir" |] |]
               [| box [| "--skip-empty-dir"; "--include-hidden-files" |] |] ]
@@ -57,7 +58,6 @@ type FsTempDirSetupFixture() =
         // Dir a has a couple of files.
         Directory.CreateDirectory(Path.Combine(projectDir, "a")) |> ignore
         File.WriteAllText(Path.Combine(projectDir, "a", "a1.txt"), "a1")
-        File.WriteAllText(Path.Combine(projectDir, "a", "a2.txt"), "a2")
         File.WriteAllText(Path.Combine(projectDir, "a", "a2.txt"), "a2")
 
         // Dir b has a sub dir and a file within that.

--- a/src/App/App.fsproj
+++ b/src/App/App.fsproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>hashdir</AssemblyName>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <Company></Company>
     <Authors>Anu Bandi</Authors>
     <PackageProjectUrl>https://ultimateanu.github.io/hashdir</PackageProjectUrl>
@@ -33,7 +33,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="7.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
   </ItemGroup>
 

--- a/src/App/App.fsproj
+++ b/src/App/App.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>hashdir</AssemblyName>
     <Version>1.2.0</Version>
     <Company></Company>

--- a/src/App/App.fsproj
+++ b/src/App/App.fsproj
@@ -33,6 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="7.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
   </ItemGroup>
 

--- a/src/App/App.fsproj
+++ b/src/App/App.fsproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -42,10 +42,6 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="7.0.200" />
   </ItemGroup>
 
 </Project>

--- a/src/App/App.fsproj
+++ b/src/App/App.fsproj
@@ -11,6 +11,7 @@
     <RepositoryUrl>https://github.com/ultimateanu/hashdir</RepositoryUrl>
     <Description>A command line utility to hash directories and files.</Description>
     <PublishReadyToRunShowWarnings>true</PublishReadyToRunShowWarnings>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 
     <!-- Create NuGet tool -->
     <Title>hashdir</Title>
@@ -41,6 +42,10 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="7.0.200" />
   </ItemGroup>
 
 </Project>

--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -3,6 +3,7 @@ open HashUtil.FS
 open HashUtil.Hashing
 open HashUtil.Util
 open HashUtil.Verification
+open Microsoft.Extensions.FileSystemGlobbing
 open System
 open System.CommandLine
 open System.CommandLine.Invocation
@@ -100,6 +101,10 @@ let rootHandler (opt: RootOpt) =
         let hashingProgressObserver = Progress.HashingObserver()
 
         let path = cleanPath pathRaw
+
+        // TODO: use this to filter files
+        let fileMatcher = new Matcher()
+        fileMatcher.AddExcludePatterns opt.Ignore
 
         let hashingTask =
             Async.StartAsTask

--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -18,7 +18,7 @@ type RootOpt
         save,
         includeHiddenFiles,
         skipEmptyDir,
-        ignorePatterns,
+        ignore,
         hashOnly,
         algorithm,
         color: bool
@@ -31,7 +31,7 @@ type RootOpt
     member val Save: bool = save
     member val IncludeHiddenFiles: bool = includeHiddenFiles
     member val SkipEmptyDir: bool = skipEmptyDir
-    member val IgnorePatterns: string[] = ignorePatterns
+    member val IgnorePatterns: string[] = ignore
     member val HashOnly: bool = hashOnly
 
     member val Algorithm: HashType =
@@ -59,22 +59,15 @@ type RootOpt
 
 
 type CheckOpt
-    (
-        item,
-        includeHiddenFiles,
-        skipEmptyDir,
-        ignorePatterns,
-        algorithm,
-        verbosity,
-        color
-    ) =
+    (item, includeHiddenFiles, skipEmptyDir, ignore, algorithm, verbosity, color)
+    =
     // Arguments
     member val Items: string[] = item
 
     // Options
     member val IncludeHiddenFiles: bool = includeHiddenFiles
     member val SkipEmptyDir: bool = skipEmptyDir
-    member val IgnorePatterns: string[] = ignorePatterns
+    member val IgnorePatterns: string[] = ignore
 
     member val Algorithm: HashType option =
         match algorithm with

--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -164,6 +164,7 @@ let checkHandler (opt: CheckOpt) =
             <| verifyHashFile
                 hashingProgressObserver
                 opt.Algorithm
+                opt.IgnorePatterns
                 opt.IncludeHiddenFiles
                 (not opt.SkipEmptyDir)
                 hashFile

--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -290,7 +290,7 @@ let checkCmd =
 
 let rootCmd =
     let root =
-        RootCommand("A command-line utility to checksum directories and files.")
+        RootCommand("A command-line utility to hash directories and files.")
 
     // Check (verb command)
     root.AddCommand checkCmd

--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -18,6 +18,7 @@ type RootOpt
         save,
         includeHiddenFiles,
         skipEmptyDir,
+        ignore,
         hashOnly,
         algorithm,
         color: bool
@@ -30,6 +31,7 @@ type RootOpt
     member val Save: bool = save
     member val IncludeHiddenFiles: bool = includeHiddenFiles
     member val SkipEmptyDir: bool = skipEmptyDir
+    member val Ignore: string[] = ignore
     member val HashOnly: bool = hashOnly
 
     member val Algorithm: HashType =
@@ -44,32 +46,28 @@ type RootOpt
 
     override x.ToString() =
         sprintf
-            "RootOpt[Items:%A PrintTree:%A Save:%A IncludeHiddenFiles:%A SkipEmptyDir:%A HashOnly:%A Algorithm:%A Color:%A]"
+            "RootOpt[Items:%A PrintTree:%A Save:%A IncludeHiddenFiles:%A SkipEmptyDir:%A Ignore:%A HashOnly:%A Algorithm:%A Color:%A]"
             x.Items
             x.PrintTree
             x.Save
             x.IncludeHiddenFiles
             x.SkipEmptyDir
+            x.Ignore
             x.HashOnly
             x.Algorithm
             x.Color
 
 
 type CheckOpt
-    (
-        item,
-        includeHiddenFiles,
-        skipEmptyDir,
-        algorithm,
-        verbosity,
-        color
-    ) =
+    (item, includeHiddenFiles, skipEmptyDir, ignore, algorithm, verbosity, color)
+    =
     // Arguments
     member val Items: string[] = item
 
     // Options
     member val IncludeHiddenFiles: bool = includeHiddenFiles
     member val SkipEmptyDir: bool = skipEmptyDir
+    member val Ignore: string[] = ignore
 
     member val Algorithm: HashType option =
         match algorithm with
@@ -88,10 +86,11 @@ type CheckOpt
 
     override x.ToString() =
         sprintf
-            "CheckOpt[Items:%A IncludeHiddenFiles:%A SkipEmptyDir:%A Algorithm:%A Color:%A]"
+            "CheckOpt[Items:%A IncludeHiddenFiles:%A SkipEmptyDir:%A Ignore:%A Algorithm:%A Color:%A]"
             x.Items
             x.IncludeHiddenFiles
             x.SkipEmptyDir
+            x.Ignore
             x.Algorithm
             x.Color
 
@@ -248,6 +247,14 @@ let hiddenFilesOpt =
 let skipEmptyOpt =
     Option<bool>([| "-e"; "--skip-empty-dir" |], "Skip empty directories")
 
+let ignoreArg = Argument<string[]>("pattern", "Pattern to ignore")
+ignoreArg.Arity <- ArgumentArity.OneOrMore
+
+let ignoreOpt =
+    Option<string[]>([| "-n"; "--ignore" |], "Directories/files to not include")
+
+ignoreOpt.Argument <- ignoreArg
+
 let hashOnlyOpt = Option<bool>([| "-h"; "--hash-only" |], "Print only the hash")
 
 let verbosityOpt =
@@ -274,6 +281,7 @@ let checkCmd =
     // OPTIONS
     checkCmd.AddOption hiddenFilesOpt
     checkCmd.AddOption skipEmptyOpt
+    checkCmd.AddOption ignoreOpt
     checkCmd.AddOption(algorithmOpt true)
     checkCmd.AddOption verbosityOpt
     checkCmd.Handler <- CommandHandler.Create(checkHandler)
@@ -299,6 +307,7 @@ let rootCmd =
 
     root.AddOption hiddenFilesOpt
     root.AddOption skipEmptyOpt
+    root.AddOption ignoreOpt
     root.AddOption hashOnlyOpt
     root.AddOption(algorithmOpt false)
     root.AddOption colorOpt

--- a/src/App/Program.fs
+++ b/src/App/Program.fs
@@ -3,7 +3,6 @@ open HashUtil.FS
 open HashUtil.Hashing
 open HashUtil.Util
 open HashUtil.Verification
-open Microsoft.Extensions.FileSystemGlobbing
 open System
 open System.CommandLine
 open System.CommandLine.Invocation
@@ -102,17 +101,16 @@ let rootHandler (opt: RootOpt) =
 
         let path = cleanPath pathRaw
 
-        // TODO: use this to filter files
-        let fileMatcher = new Matcher()
-        fileMatcher.AddExcludePatterns opt.Ignore
 
         let hashingTask =
             Async.StartAsTask
             <| makeHashStructureObservable
                 hashingProgressObserver
                 opt.Algorithm
+                opt.Ignore
                 opt.IncludeHiddenFiles
                 (not opt.SkipEmptyDir)
+                path
                 path
 
         // Show progress while hashing happens in background.

--- a/src/App/Properties/PublishProfiles/binary.pubxml
+++ b/src/App/Properties/PublishProfiles/binary.pubxml
@@ -6,9 +6,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>Any CPU</Platform>
-    <PublishDir>bin\Release\net6.0\publish\binary</PublishDir>
+    <PublishDir>bin\Release\net7.0\publish\binary</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>True</SelfContained>
     <PublishSingleFile>True</PublishSingleFile>

--- a/src/App/Properties/PublishProfiles/binary.pubxml
+++ b/src/App/Properties/PublishProfiles/binary.pubxml
@@ -13,7 +13,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <SelfContained>True</SelfContained>
     <PublishSingleFile>True</PublishSingleFile>
     <PublishReadyToRun>True</PublishReadyToRun>
-    <PublishTrimmed>True</PublishTrimmed>
+    <!-- <PublishTrimmed>True</PublishTrimmed> -->
     <IncludeAllContentForSelfExtract>True</IncludeAllContentForSelfExtract>
     <DebugSymbols>False</DebugSymbols>
     <DebugType>None</DebugType>

--- a/src/App/Properties/PublishProfiles/dotnet.pubxml
+++ b/src/App/Properties/PublishProfiles/dotnet.pubxml
@@ -6,9 +6,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>Any CPU</Platform>
-    <PublishDir>bin\Release\net6.0\publish\dotnet</PublishDir>
+    <PublishDir>bin\Release\net7.0\publish\dotnet</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <SelfContained>false</SelfContained>
   </PropertyGroup>
 </Project>

--- a/src/App/Properties/launchSettings.json
+++ b/src/App/Properties/launchSettings.json
@@ -18,7 +18,7 @@
     },
     "Desktop ignore --tree": {
       "commandName": "Project",
-      "commandLineArgs": "--ignore \"node_mod\" --tree C:\\Users\\ultim\\Desktop\\test"
+      "commandLineArgs": "--ignore \"**/node_mod\" --ignore \"**/*.jpg\" --tree C:\\Users\\ultim\\Desktop\\test"
     },
     "Desktop check": {
       "commandName": "Project",

--- a/src/App/Properties/launchSettings.json
+++ b/src/App/Properties/launchSettings.json
@@ -18,7 +18,7 @@
     },
     "Desktop ignore --tree": {
       "commandName": "Project",
-      "commandLineArgs": "--ignore \"**/node_mod\" --ignore \"**/*.jpg\" --tree C:\\Users\\ultim\\Desktop\\test"
+      "commandLineArgs": "--tree --ignore \"**/node_mod\" --ignore \"**/*.jpg\" C:\\Users\\ultim\\Desktop\\test"
     },
     "Desktop check": {
       "commandName": "Project",

--- a/src/App/Properties/launchSettings.json
+++ b/src/App/Properties/launchSettings.json
@@ -16,9 +16,9 @@
       "commandName": "Project",
       "commandLineArgs": "--skip-empty-dir --tree C:\\Users\\ultim\\Desktop\\test"
     },
-    "Desktop --tree": {
+    "Desktop ignore --tree": {
       "commandName": "Project",
-      "commandLineArgs": "--tree C:\\Users\\ultim\\Desktop\\test"
+      "commandLineArgs": "--ignore \"node_mod\" --tree C:\\Users\\ultim\\Desktop\\test"
     },
     "Desktop check": {
       "commandName": "Project",

--- a/src/Checksums/Checksums.csproj
+++ b/src/Checksums/Checksums.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/HashUtil.Tests/FsTests.fs
+++ b/src/HashUtil.Tests/FsTests.fs
@@ -10,10 +10,16 @@ open System.Runtime.InteropServices
 open Xunit
 open Xunit.Abstractions
 
+
 type FsTempDirSetupFixture() =
     // Single temp dir which always gets cleaned up.
     let tempDir =
-        Path.GetFullPath(Path.Combine(Path.GetTempPath(), "hashdir_test_" + Guid.NewGuid().ToString()))
+        Path.GetFullPath(
+            Path.Combine(
+                Path.GetTempPath(),
+                "hashdir_test_" + Guid.NewGuid().ToString()
+            )
+        )
 
     // SETUP
     do Directory.CreateDirectory(tempDir) |> ignore
@@ -25,7 +31,8 @@ type FsTempDirSetupFixture() =
     member _.TempDir = tempDir
 
 
-type FilenameInHash(fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestOutputHelper) =
+type FilenameInHash
+    (fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestOutputHelper) =
     // Create root dir for each test.
     let rootDir =
         Path.Combine(fsTempDirSetupFixture.TempDir, "filename_in_hash_root_dir")
@@ -40,7 +47,9 @@ type FilenameInHash(fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestO
     interface IClassFixture<FsTempDirSetupFixture>
 
     [<Fact>]
-    member _.``Dir hashs same when child files/dirs have same names & content``() =
+    member _.``Dir hashs same when child files/dirs have same names & content``
+        ()
+        =
         // Setup two directories with files/dirs of same name and content.
         let dirA = Path.Combine(rootDir, "dir_a")
         let dirAInternal = Path.Combine(dirA, "internal")
@@ -52,8 +61,16 @@ type FilenameInHash(fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestO
         Directory.CreateDirectory(dirBInternal) |> ignore
         File.WriteAllText(Path.Combine(dirA, "file_a.txt"), "content_top")
         File.WriteAllText(Path.Combine(dirB, "file_a.txt"), "content_top")
-        File.WriteAllText(Path.Combine(dirAInternal, "file.txt"), "content_internal")
-        File.WriteAllText(Path.Combine(dirBInternal, "file.txt"), "content_internal")
+
+        File.WriteAllText(
+            Path.Combine(dirAInternal, "file.txt"),
+            "content_internal"
+        )
+
+        File.WriteAllText(
+            Path.Combine(dirBInternal, "file.txt"),
+            "content_internal"
+        )
 
         // Compute the hash of the two directories.
         let includeHiddenFiles = true
@@ -61,12 +78,18 @@ type FilenameInHash(fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestO
 
         let dirAHash =
             dirA
-            |> makeHashStructure HashType.SHA256 includeHiddenFiles includeEmptyDir
+            |> makeHashStructure
+                HashType.SHA256
+                includeHiddenFiles
+                includeEmptyDir
             |> makeOption
 
         let dirBHash =
             dirB
-            |> makeHashStructure HashType.SHA256 includeHiddenFiles includeEmptyDir
+            |> makeHashStructure
+                HashType.SHA256
+                includeHiddenFiles
+                includeEmptyDir
             |> makeOption
 
         // Expect their hashes to be equal.
@@ -85,8 +108,16 @@ type FilenameInHash(fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestO
         Directory.CreateDirectory(dirBInternal) |> ignore
         File.WriteAllText(Path.Combine(dirA, "file_a.txt"), "content_top")
         File.WriteAllText(Path.Combine(dirB, "file_b.txt"), "content_top")
-        File.WriteAllText(Path.Combine(dirAInternal, "file.txt"), "content_internal")
-        File.WriteAllText(Path.Combine(dirBInternal, "file.txt"), "content_internal")
+
+        File.WriteAllText(
+            Path.Combine(dirAInternal, "file.txt"),
+            "content_internal"
+        )
+
+        File.WriteAllText(
+            Path.Combine(dirBInternal, "file.txt"),
+            "content_internal"
+        )
 
         // Compute the hash of the two directories.
         let includeHiddenFiles = true
@@ -94,12 +125,18 @@ type FilenameInHash(fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestO
 
         let dirAHash =
             dirA
-            |> makeHashStructure HashType.SHA256 includeHiddenFiles includeEmptyDir
+            |> makeHashStructure
+                HashType.SHA256
+                includeHiddenFiles
+                includeEmptyDir
             |> makeOption
 
         let dirBHash =
             dirB
-            |> makeHashStructure HashType.SHA256 includeHiddenFiles includeEmptyDir
+            |> makeHashStructure
+                HashType.SHA256
+                includeHiddenFiles
+                includeEmptyDir
             |> makeOption
 
         // Expect their hashes to be different.
@@ -118,8 +155,16 @@ type FilenameInHash(fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestO
         Directory.CreateDirectory(dirBInternal) |> ignore
         File.WriteAllText(Path.Combine(dirA, "file_root.txt"), "content_top")
         File.WriteAllText(Path.Combine(dirB, "file_root.txt"), "content_top")
-        File.WriteAllText(Path.Combine(dirAInternal, "file.txt"), "content_internal")
-        File.WriteAllText(Path.Combine(dirBInternal, "file.txt"), "content_internal")
+
+        File.WriteAllText(
+            Path.Combine(dirAInternal, "file.txt"),
+            "content_internal"
+        )
+
+        File.WriteAllText(
+            Path.Combine(dirBInternal, "file.txt"),
+            "content_internal"
+        )
 
         // Compute the hash of the two directories.
         let includeHiddenFiles = true
@@ -127,22 +172,28 @@ type FilenameInHash(fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestO
 
         let dirAHash =
             dirA
-            |> makeHashStructure HashType.SHA256 includeHiddenFiles includeEmptyDir
+            |> makeHashStructure
+                HashType.SHA256
+                includeHiddenFiles
+                includeEmptyDir
             |> makeOption
 
         let dirBHash =
             dirB
-            |> makeHashStructure HashType.SHA256 includeHiddenFiles includeEmptyDir
+            |> makeHashStructure
+                HashType.SHA256
+                includeHiddenFiles
+                includeEmptyDir
             |> makeOption
 
         // Expect their hashes to be different.
         Assert.NotEqual<string>(getHash dirAHash.Value, getHash dirBHash.Value)
 
 
-type HashProperties(fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestOutputHelper) =
+type HashProperties
+    (fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestOutputHelper) =
     // Create root dir for each test.
-    let rootDir =
-        Path.Combine(fsTempDirSetupFixture.TempDir, "hash_properties")
+    let rootDir = Path.Combine(fsTempDirSetupFixture.TempDir, "hash_properties")
 
     // SETUP
     do Directory.CreateDirectory(rootDir) |> ignore
@@ -167,12 +218,18 @@ type HashProperties(fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestO
 
         let dirHash =
             dirPath
-            |> makeHashStructure HashType.SHA256 includeHiddenFiles includeEmptyDir
+            |> makeHashStructure
+                HashType.SHA256
+                includeHiddenFiles
+                includeEmptyDir
             |> makeOption
 
         let fileHash =
             filePath
-            |> makeHashStructure HashType.SHA256 includeHiddenFiles includeEmptyDir
+            |> makeHashStructure
+                HashType.SHA256
+                includeHiddenFiles
+                includeEmptyDir
             |> makeOption
 
         // Expect their hashes to be equal.
@@ -181,9 +238,9 @@ type HashProperties(fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestO
         Assert.Equal(getHash dirHash.Value, getHash fileHash.Value)
 
 
-type FileHashes(fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestOutputHelper) =
-    let hiddenFilePath =
-        Path.Combine(fsTempDirSetupFixture.TempDir, ".fakerc")
+type FileHashes
+    (fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestOutputHelper) =
+    let hiddenFilePath = Path.Combine(fsTempDirSetupFixture.TempDir, ".fakerc")
 
     // SETUP
     do
@@ -210,7 +267,11 @@ type FileHashes(fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestOutpu
 
         // Hash should exist and match
         Assert.True(fileHash.IsSome)
-        Assert.Equal("b79606fb3afea5bd1609ed40b622142f1c98125abcfe89a76a661b0e8e343910", getHash fileHash.Value)
+
+        Assert.Equal(
+            "b79606fb3afea5bd1609ed40b622142f1c98125abcfe89a76a661b0e8e343910",
+            getHash fileHash.Value
+        )
 
     [<Fact>]
     member _.``Hidden file (exclude)``() =
@@ -226,14 +287,14 @@ type FileHashes(fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestOutpu
         Assert.True(fileHash.IsNone)
 
 
-type DirHashes(fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestOutputHelper) =
+type DirHashes
+    (fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestOutputHelper) =
     interface IClassFixture<FsTempDirSetupFixture>
 
     [<Fact>]
     member _.``Dir with 0 files (include empty dir)``() =
         // Setup dir with 0 files
-        let dirZero =
-            Path.Combine(fsTempDirSetupFixture.TempDir, "dir_zero")
+        let dirZero = Path.Combine(fsTempDirSetupFixture.TempDir, "dir_zero")
 
         Directory.CreateDirectory(dirZero) |> ignore
 
@@ -247,13 +308,16 @@ type DirHashes(fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestOutput
 
         // Hash should exist and match
         Assert.True(zeroFileDirHash.IsSome)
-        Assert.Equal("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", getHash zeroFileDirHash.Value)
+
+        Assert.Equal(
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            getHash zeroFileDirHash.Value
+        )
 
     [<Fact>]
     member _.``Dir with 0 files (exclude empty dir)``() =
         // Setup dir with 0 files
-        let dirZero =
-            Path.Combine(fsTempDirSetupFixture.TempDir, "dir_zero")
+        let dirZero = Path.Combine(fsTempDirSetupFixture.TempDir, "dir_zero")
 
         Directory.CreateDirectory(dirZero) |> ignore
 
@@ -271,27 +335,27 @@ type DirHashes(fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestOutput
     [<Fact>]
     member _.``Dir with 1 file``() =
         // Setup dir with 1 file
-        let dirOne =
-            Path.Combine(fsTempDirSetupFixture.TempDir, "dir_one")
+        let dirOne = Path.Combine(fsTempDirSetupFixture.TempDir, "dir_one")
 
         Directory.CreateDirectory(dirOne) |> ignore
         File.WriteAllText(Path.Combine(dirOne, "file1.txt"), "1")
 
         // Compute hash
         let oneFileDirHash =
-            dirOne
-            |> makeHashStructure SHA256 false false
-            |> makeOption
+            dirOne |> makeHashStructure SHA256 false false |> makeOption
 
         // Hash should exist and match
         Assert.True(oneFileDirHash.IsSome)
-        Assert.Equal("c0b9c17c8ac302513644256d06d1518a50c0c349e28023c2795a17dfa5479e1f", getHash oneFileDirHash.Value)
+
+        Assert.Equal(
+            "c0b9c17c8ac302513644256d06d1518a50c0c349e28023c2795a17dfa5479e1f",
+            getHash oneFileDirHash.Value
+        )
 
     [<Fact>]
     member _.``Dir with 2 files``() =
         // Setup dir with 2 files
-        let dirTwo =
-            Path.Combine(fsTempDirSetupFixture.TempDir, "dir_two")
+        let dirTwo = Path.Combine(fsTempDirSetupFixture.TempDir, "dir_two")
 
         Directory.CreateDirectory(dirTwo) |> ignore
         File.WriteAllText(Path.Combine(dirTwo, "file1.txt"), "1")
@@ -299,29 +363,39 @@ type DirHashes(fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestOutput
 
         // Compute hash
         let twoFileDirHash =
-            dirTwo
-            |> makeHashStructure SHA256 false false
-            |> makeOption
+            dirTwo |> makeHashStructure SHA256 false false |> makeOption
 
         // Hash should exist and match
         Assert.True(twoFileDirHash.IsSome)
-        Assert.Equal("072d85c3b6926317ee8c340d4e989c9588c75408e63b5674571624a096faf9b5", getHash twoFileDirHash.Value)
 
-type FullTreeHash(fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestOutputHelper) =
-    let rootDir =
-        Path.Combine(fsTempDirSetupFixture.TempDir, "root")
+        Assert.Equal(
+            "072d85c3b6926317ee8c340d4e989c9588c75408e63b5674571624a096faf9b5",
+            getHash twoFileDirHash.Value
+        )
+
+type FullTreeHash
+    (fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestOutputHelper) =
+    let rootDir = Path.Combine(fsTempDirSetupFixture.TempDir, "root")
 
     // SETUP
     do
         // Root dir has a single file
         Directory.CreateDirectory(rootDir) |> ignore
-        File.WriteAllText(Path.Combine(rootDir, "shakespeare.txt"), "To be or not to be...")
+
+        File.WriteAllText(
+            Path.Combine(rootDir, "shakespeare.txt"),
+            "To be or not to be..."
+        )
         // Dir A has sub dirs
         let dirA = Path.Combine(rootDir, "dir_a")
         let dirAInner = Path.Combine(dirA, "inner")
         Directory.CreateDirectory(dirA) |> ignore
         Directory.CreateDirectory(dirAInner) |> ignore
-        File.WriteAllText(Path.Combine(dirAInner, "inner_1.txt"), "inner file 1")
+
+        File.WriteAllText(
+            Path.Combine(dirAInner, "inner_1.txt"),
+            "inner file 1"
+        )
         // Dir B has multiple files
         let dirB = Path.Combine(rootDir, "dir_b")
         Directory.CreateDirectory(dirB) |> ignore
@@ -367,7 +441,11 @@ type FullTreeHash(fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestOut
             |> makeOption
 
         Assert.True(rootHash.IsSome)
-        Assert.Equal("a7bd95e3686bf708684575ad945e6ad999bbf71e811c108bdce1e39b6d6cd66f", getHash rootHash.Value)
+
+        Assert.Equal(
+            "a7bd95e3686bf708684575ad945e6ad999bbf71e811c108bdce1e39b6d6cd66f",
+            getHash rootHash.Value
+        )
 
     [<Fact>]
     member _.``Full tree hash (include hidden, exclude empty dir)``() =
@@ -380,7 +458,11 @@ type FullTreeHash(fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestOut
             |> makeOption
 
         Assert.True(rootHash.IsSome)
-        Assert.Equal("316f1288632d00417e849505d8a70e3cf368fe4714e24bded2425655995fe601", getHash rootHash.Value)
+
+        Assert.Equal(
+            "316f1288632d00417e849505d8a70e3cf368fe4714e24bded2425655995fe601",
+            getHash rootHash.Value
+        )
 
     [<Fact>]
     member _.``Full tree hash (exclude hidden, include empty dir)``() =
@@ -393,7 +475,11 @@ type FullTreeHash(fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestOut
             |> makeOption
 
         Assert.True(rootHash.IsSome)
-        Assert.Equal("82268ca33494bec2d17e1bcad8ac73744544183ef1d6b2c25b0988f88064f180", getHash rootHash.Value)
+
+        Assert.Equal(
+            "82268ca33494bec2d17e1bcad8ac73744544183ef1d6b2c25b0988f88064f180",
+            getHash rootHash.Value
+        )
 
     [<Fact>]
     member _.``Full tree hash (exclude hidden, exclude empty dir)``() =
@@ -406,4 +492,8 @@ type FullTreeHash(fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestOut
             |> makeOption
 
         Assert.True(rootHash.IsSome)
-        Assert.Equal("1ae01db575f5965c003d47c026cb0bc141de0fb4897713a54a5296651ad743db", getHash rootHash.Value)
+
+        Assert.Equal(
+            "1ae01db575f5965c003d47c026cb0bc141de0fb4897713a54a5296651ad743db",
+            getHash rootHash.Value
+        )

--- a/src/HashUtil.Tests/FsTests.fs
+++ b/src/HashUtil.Tests/FsTests.fs
@@ -80,6 +80,7 @@ type FilenameInHash
             dirA
             |> makeHashStructure
                 HashType.SHA256
+                (* ignorePatterns= *) [||]
                 includeHiddenFiles
                 includeEmptyDir
             |> makeOption
@@ -88,6 +89,7 @@ type FilenameInHash
             dirB
             |> makeHashStructure
                 HashType.SHA256
+                (* ignorePatterns= *) [||]
                 includeHiddenFiles
                 includeEmptyDir
             |> makeOption
@@ -127,6 +129,7 @@ type FilenameInHash
             dirA
             |> makeHashStructure
                 HashType.SHA256
+                (* ignorePatterns= *) [||]
                 includeHiddenFiles
                 includeEmptyDir
             |> makeOption
@@ -135,6 +138,7 @@ type FilenameInHash
             dirB
             |> makeHashStructure
                 HashType.SHA256
+                (* ignorePatterns= *) [||]
                 includeHiddenFiles
                 includeEmptyDir
             |> makeOption
@@ -174,6 +178,7 @@ type FilenameInHash
             dirA
             |> makeHashStructure
                 HashType.SHA256
+                (* ignorePatterns= *) [||]
                 includeHiddenFiles
                 includeEmptyDir
             |> makeOption
@@ -182,6 +187,7 @@ type FilenameInHash
             dirB
             |> makeHashStructure
                 HashType.SHA256
+                (* ignorePatterns= *) [||]
                 includeHiddenFiles
                 includeEmptyDir
             |> makeOption
@@ -220,6 +226,7 @@ type HashProperties
             dirPath
             |> makeHashStructure
                 HashType.SHA256
+                (* ignorePatterns= *) [||]
                 includeHiddenFiles
                 includeEmptyDir
             |> makeOption
@@ -228,6 +235,7 @@ type HashProperties
             filePath
             |> makeHashStructure
                 HashType.SHA256
+                (* ignorePatterns= *) [||]
                 includeHiddenFiles
                 includeEmptyDir
             |> makeOption
@@ -262,7 +270,11 @@ type FileHashes
 
         let fileHash =
             hiddenFilePath
-            |> makeHashStructure SHA256 includeHiddenFiles true
+            |> makeHashStructure
+                SHA256
+                (* ignorePatterns= *) [||]
+                includeHiddenFiles
+                true
             |> makeOption
 
         // Hash should exist and match
@@ -280,7 +292,11 @@ type FileHashes
 
         let fileHash =
             hiddenFilePath
-            |> makeHashStructure SHA256 includeHiddenFiles true
+            |> makeHashStructure
+                SHA256
+                (* ignorePatterns= *) [||]
+                includeHiddenFiles
+                true
             |> makeOption
 
         // Hash should exist and match
@@ -303,7 +319,11 @@ type DirHashes
 
         let zeroFileDirHash =
             dirZero
-            |> makeHashStructure SHA256 false includeEmptyDir
+            |> makeHashStructure
+                SHA256
+                (* ignorePatterns= *) [||]
+                false
+                includeEmptyDir
             |> makeOption
 
         // Hash should exist and match
@@ -326,7 +346,11 @@ type DirHashes
 
         let zeroFileDirHash =
             dirZero
-            |> makeHashStructure SHA256 false includeEmptyDir
+            |> makeHashStructure
+                SHA256
+                (* ignorePatterns= *) [||]
+                false
+                includeEmptyDir
             |> makeOption
 
         // Hash should exist and match
@@ -342,7 +366,13 @@ type DirHashes
 
         // Compute hash
         let oneFileDirHash =
-            dirOne |> makeHashStructure SHA256 false false |> makeOption
+            dirOne
+            |> makeHashStructure
+                SHA256
+                (* ignorePatterns= *) [||]
+                false
+                false
+            |> makeOption
 
         // Hash should exist and match
         Assert.True(oneFileDirHash.IsSome)
@@ -363,7 +393,13 @@ type DirHashes
 
         // Compute hash
         let twoFileDirHash =
-            dirTwo |> makeHashStructure SHA256 false false |> makeOption
+            dirTwo
+            |> makeHashStructure
+                SHA256
+                (* ignorePatterns= *) [||]
+                false
+                false
+            |> makeOption
 
         // Hash should exist and match
         Assert.True(twoFileDirHash.IsSome)
@@ -437,7 +473,11 @@ type FullTreeHash
 
         let rootHash =
             rootDir
-            |> makeHashStructure SHA256 includeHiddenFiles includeEmptyDir
+            |> makeHashStructure
+                SHA256
+                (* ignorePatterns= *) [||]
+                includeHiddenFiles
+                includeEmptyDir
             |> makeOption
 
         Assert.True(rootHash.IsSome)
@@ -454,7 +494,11 @@ type FullTreeHash
 
         let rootHash =
             rootDir
-            |> makeHashStructure SHA256 includeHiddenFiles includeEmptyDir
+            |> makeHashStructure
+                SHA256
+                (* ignorePatterns= *) [||]
+                includeHiddenFiles
+                includeEmptyDir
             |> makeOption
 
         Assert.True(rootHash.IsSome)
@@ -471,7 +515,11 @@ type FullTreeHash
 
         let rootHash =
             rootDir
-            |> makeHashStructure SHA256 includeHiddenFiles includeEmptyDir
+            |> makeHashStructure
+                SHA256
+                (* ignorePatterns= *) [||]
+                includeHiddenFiles
+                includeEmptyDir
             |> makeOption
 
         Assert.True(rootHash.IsSome)
@@ -488,7 +536,11 @@ type FullTreeHash
 
         let rootHash =
             rootDir
-            |> makeHashStructure SHA256 includeHiddenFiles includeEmptyDir
+            |> makeHashStructure
+                SHA256
+                (* ignorePatterns= *) [||]
+                includeHiddenFiles
+                includeEmptyDir
             |> makeOption
 
         Assert.True(rootHash.IsSome)
@@ -497,3 +549,202 @@ type FullTreeHash
             "1ae01db575f5965c003d47c026cb0bc141de0fb4897713a54a5296651ad743db",
             getHash rootHash.Value
         )
+
+
+type IgnorePatterns
+    (fsTempDirSetupFixture: FsTempDirSetupFixture, output: ITestOutputHelper) =
+    let rootDir = Path.Combine(fsTempDirSetupFixture.TempDir, "root")
+
+    // SETUP
+    do
+        // Root dir has several files
+        Directory.CreateDirectory(rootDir) |> ignore
+        File.WriteAllText(Path.Combine(rootDir, "z1.txt"), "z1")
+        File.WriteAllText(Path.Combine(rootDir, "z1.csv"), "z1d")
+        File.WriteAllText(Path.Combine(rootDir, "z2.txt"), "z2")
+        File.WriteAllText(Path.Combine(rootDir, "z2.csv"), "z2d")
+
+        // Dir A has sub dirs
+        let dirA = Path.Combine(rootDir, "dir_a")
+        let dirANode = Path.Combine(dirA, "node")
+        let dirAInner = Path.Combine(dirA, "inner")
+        Directory.CreateDirectory(dirA) |> ignore
+        Directory.CreateDirectory(dirANode) |> ignore
+        Directory.CreateDirectory(dirAInner) |> ignore
+        File.WriteAllText(Path.Combine(dirANode, "a_node.txt"), "an")
+        File.WriteAllText(Path.Combine(dirANode, "a_node.csv"), "an csv")
+        File.WriteAllText(Path.Combine(dirAInner, "inner_a1.txt"), "aaa")
+        File.WriteAllText(Path.Combine(dirAInner, "inner_a1.csv"), "aaa csv")
+
+        // Dir B has sub dirs
+        let dirB = Path.Combine(rootDir, "dir_b")
+        let dirBInner = Path.Combine(dirB, "inner")
+        let dirBNode = Path.Combine(dirBInner, "node")
+        Directory.CreateDirectory(dirB) |> ignore
+        Directory.CreateDirectory(dirBInner) |> ignore
+        Directory.CreateDirectory(dirBNode) |> ignore
+        File.WriteAllText(Path.Combine(dirBInner, "inner_b1.txt"), "bbb")
+        File.WriteAllText(Path.Combine(dirBInner, "inner_b1.csv"), "bbb csv")
+        File.WriteAllText(Path.Combine(dirBNode, "b_node.txt"), "bn")
+        File.WriteAllText(Path.Combine(dirBNode, "b_node.csv"), "bn csv")
+
+        // Dir node has sub dirs
+        let dirNode = Path.Combine(rootDir, "node")
+        let dirNodeInner = Path.Combine(dirNode, "inner")
+        Directory.CreateDirectory(dirNode) |> ignore
+        Directory.CreateDirectory(dirNodeInner) |> ignore
+        File.WriteAllText(Path.Combine(dirNodeInner, "node.txt"), "node")
+        File.WriteAllText(Path.Combine(dirNodeInner, "node.csv"), "node csv")
+
+    // CLEANUP
+    interface IDisposable with
+        member this.Dispose() = Directory.Delete(rootDir, true)
+
+    interface IClassFixture<FsTempDirSetupFixture>
+
+    [<Fact>]
+    member _.``Ignore single file``() =
+        let ignorePatterns = [| "z1.txt" |]
+
+        let rootHash =
+            rootDir
+            |> makeHashStructure
+                HashType.MD5
+                ignorePatterns
+                (* includeHiddenFiles= *) true
+                (* includeEmptyDir= *) true
+            |> makeOption
+
+        Assert.True(rootHash.IsSome)
+
+        let strWriter = new StringWriter()
+        printHashStructure rootHash.Value true false strWriter true
+        output.WriteLine(strWriter.ToString())
+
+        Assert.Equal("c817e3d89464e80a2fca714089eaafbc", getHash rootHash.Value)
+
+    [<Fact>]
+    member _.``Ignore single dir``() =
+        let ignorePatterns = [| "node" |]
+
+        let rootHash =
+            rootDir
+            |> makeHashStructure
+                HashType.MD5
+                ignorePatterns
+                (* includeHiddenFiles= *) true
+                (* includeEmptyDir= *) true
+            |> makeOption
+
+        Assert.True(rootHash.IsSome)
+
+        let strWriter = new StringWriter()
+        printHashStructure rootHash.Value true false strWriter true
+        output.WriteLine(strWriter.ToString())
+
+        Assert.Equal("89b9a43ef7b35f697ed85f91a5a7eafd", getHash rootHash.Value)
+
+    [<Fact>]
+    member _.``Ignore multiple items``() =
+        let ignorePatterns = [| "z1.txt"; "z2.csv"; "node" |]
+
+        let rootHash =
+            rootDir
+            |> makeHashStructure
+                HashType.MD5
+                ignorePatterns
+                (* includeHiddenFiles= *) true
+                (* includeEmptyDir= *) true
+            |> makeOption
+
+        Assert.True(rootHash.IsSome)
+
+        let strWriter = new StringWriter()
+        printHashStructure rootHash.Value true false strWriter true
+        output.WriteLine(strWriter.ToString())
+
+        Assert.Equal("d964a1f49101b8629921ea878a0f1fc7", getHash rootHash.Value)
+
+    [<Fact>]
+    member _.``Ignore an item in specific dir``() =
+        let ignorePatterns = [| "dir_a/inner/*.txt" |]
+
+        let rootHash =
+            rootDir
+            |> makeHashStructure
+                HashType.MD5
+                ignorePatterns
+                (* includeHiddenFiles= *) true
+                (* includeEmptyDir= *) true
+            |> makeOption
+
+        Assert.True(rootHash.IsSome)
+
+        let strWriter = new StringWriter()
+        printHashStructure rootHash.Value true false strWriter true
+        output.WriteLine(strWriter.ToString())
+
+        Assert.Equal("010d611ad240c98ce2d50b8df978e960", getHash rootHash.Value)
+
+    [<Fact>]
+    member _.``Ignore items under specific dir``() =
+        let ignorePatterns = [| "dir_a/**/*.txt" |]
+
+        let rootHash =
+            rootDir
+            |> makeHashStructure
+                HashType.MD5
+                ignorePatterns
+                (* includeHiddenFiles= *) true
+                (* includeEmptyDir= *) true
+            |> makeOption
+
+        Assert.True(rootHash.IsSome)
+
+        let strWriter = new StringWriter()
+        printHashStructure rootHash.Value true false strWriter true
+        output.WriteLine(strWriter.ToString())
+
+        Assert.Equal("1837a19c15ac00addbccf911d527c733", getHash rootHash.Value)
+
+    [<Fact>]
+    member _.``Ignore file anywhere``() =
+        let ignorePatterns = [| "**/*.txt" |]
+
+        let rootHash =
+            rootDir
+            |> makeHashStructure
+                HashType.MD5
+                ignorePatterns
+                (* includeHiddenFiles= *) true
+                (* includeEmptyDir= *) true
+            |> makeOption
+
+        Assert.True(rootHash.IsSome)
+
+        let strWriter = new StringWriter()
+        printHashStructure rootHash.Value true false strWriter true
+        output.WriteLine(strWriter.ToString())
+
+        Assert.Equal("30f0cc375454ac1f32429abadaf4f05f", getHash rootHash.Value)
+
+    [<Fact>]
+    member _.``Ignore dir anywhere``() =
+        let ignorePatterns = [| "**/node" |]
+
+        let rootHash =
+            rootDir
+            |> makeHashStructure
+                HashType.MD5
+                ignorePatterns
+                (* includeHiddenFiles= *) true
+                (* includeEmptyDir= *) true
+            |> makeOption
+
+        Assert.True(rootHash.IsSome)
+
+        let strWriter = new StringWriter()
+        printHashStructure rootHash.Value true false strWriter true
+        output.WriteLine(strWriter.ToString())
+
+        Assert.Equal("a59a1763d85b2767792264fa16af2415", getHash rootHash.Value)

--- a/src/HashUtil.Tests/HashUtil.Tests.fsproj
+++ b/src/HashUtil.Tests/HashUtil.Tests.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>

--- a/src/HashUtil/HashUtil.fsproj
+++ b/src/HashUtil/HashUtil.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
 

--- a/src/HashUtil/HashUtil.fsproj
+++ b/src/HashUtil/HashUtil.fsproj
@@ -23,4 +23,8 @@
     <ProjectReference Include="..\Checksums\Checksums.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Glob" Version="1.2.0-alpha0037" />
+  </ItemGroup>
+
 </Project>

--- a/src/HashUtil/Hashing.fs
+++ b/src/HashUtil/Hashing.fs
@@ -147,6 +147,7 @@ module Hashing =
 
     let makeHashStructure
         (hashType: Checksum.HashType)
+        (ignorePatterns: string[])
         includeHiddenFiles
         includeEmptyDir
         path
@@ -157,7 +158,7 @@ module Hashing =
         <| makeHashStructureObservable
             emptyHashingObserver
             hashType
-            [||] // ignorePatterns
+            ignorePatterns
             includeHiddenFiles
             includeEmptyDir
             path // rootDir

--- a/src/HashUtil/Hashing.fs
+++ b/src/HashUtil/Hashing.fs
@@ -144,7 +144,7 @@ module Hashing =
 
             member this.OnNext(hashingUpdate: HashingUpdate) : unit = ()
 
-(*
+
     let makeHashStructure
         (hashType: Checksum.HashType)
         includeHiddenFiles
@@ -157,7 +157,8 @@ module Hashing =
         <| makeHashStructureObservable
             emptyHashingObserver
             hashType
+            [||] // ignorePatterns
             includeHiddenFiles
             includeEmptyDir
+            path // rootDir
             path
-    *)

--- a/src/HashUtil/Verification.fs
+++ b/src/HashUtil/Verification.fs
@@ -64,8 +64,10 @@ module Verification =
             <| Hashing.makeHashStructureObservable
                 progressObserver
                 hashType
+                [||] // TODO: fix later
                 includeHiddenFiles
                 includeEmptyDir
+                "" // TODO: fix later with root dir
                 fullPath
 
         match itemHashResult with

--- a/src/HashUtil/Verification.fs
+++ b/src/HashUtil/Verification.fs
@@ -2,7 +2,7 @@
 
 open System
 open System.IO
-open System.Text.RegularExpressions;
+open System.Text.RegularExpressions
 open Microsoft.FSharp.Reflection
 open Hashing
 
@@ -10,13 +10,14 @@ module Verification =
     let hashLengths =
         let hashTypesAndLengths =
             Checksum.allHashTypes
-            |> Array.map(fun t ->
-                (t, Util.computeHashOfString (Checksum.getHashAlgorithm t) "str"))
-            |> Array.map(fun (t,hash) -> (t,hash.Length))
+            |> Array.map (fun t ->
+                (t,
+                 Util.computeHashOfString (Checksum.getHashAlgorithm t) "str"))
+            |> Array.map (fun (t, hash) -> (t, hash.Length))
+
         let uniqueLengths =
-            hashTypesAndLengths
-            |> Array.map snd
-            |> Array.distinct
+            hashTypesAndLengths |> Array.map snd |> Array.distinct
+
         hashTypesAndLengths
 
     type VerificationResult =
@@ -28,10 +29,11 @@ module Verification =
         | Normal
         | Detailed
 
-    let allPrintVerbosity : PrintVerbosity[] =
+    let allPrintVerbosity: PrintVerbosity[] =
         typeof<PrintVerbosity>
         |> FSharpType.GetUnionCases
-        |> Array.map(fun info -> FSharpValue.MakeUnion(info,[||]) :?> PrintVerbosity)
+        |> Array.map (fun info ->
+            FSharpValue.MakeUnion(info, [||]) :?> PrintVerbosity)
 
     let parsePrintVerbosity (input: string) =
         let printVerbosityStr = input.Trim().ToLower()
@@ -42,62 +44,111 @@ module Verification =
         | "detailed" -> Some Detailed
         | _ -> None
 
-    let verifyHashAndItem (progressObserver: IObserver<HashingUpdate>) (hashType: Checksum.HashType) includeHiddenFiles
-        includeEmptyDir basePath expectedHash (path:string): Result<VerificationResult, string> =
+    let verifyHashAndItem
+        (progressObserver: IObserver<HashingUpdate>)
+        (hashType: Checksum.HashType)
+        includeHiddenFiles
+        includeEmptyDir
+        basePath
+        expectedHash
+        (path: string)
+        : Result<VerificationResult, string> =
         let fullPath =
-            Path.Join(basePath,
-                if path.StartsWith('/') then path.[1..] else path)
+            Path.Join(
+                basePath,
+                if path.StartsWith('/') then path.[1..] else path
+            )
+
         let itemHashResult =
-            Async.RunSynchronously <|
-                Hashing.makeHashStructureObservable progressObserver hashType
-                    includeHiddenFiles includeEmptyDir fullPath
+            Async.RunSynchronously
+            <| Hashing.makeHashStructureObservable
+                progressObserver
+                hashType
+                includeHiddenFiles
+                includeEmptyDir
+                fullPath
 
         match itemHashResult with
-            | Error err -> Error err
-            | Ok itemHash ->
-                let actualHash = FS.getHash itemHash
-                if actualHash = expectedHash then
-                    Ok (VerificationResult.Matches(path, actualHash))
-                else
-                    Ok (VerificationResult.Differs(path, expectedHash, actualHash))
+        | Error err -> Error err
+        | Ok itemHash ->
+            let actualHash = FS.getHash itemHash
 
-    let verifyHashAndItemByGuessing (progressObserver: IObserver<HashingUpdate>) (hashType: Checksum.HashType option) includeHiddenFiles
-        includeEmptyDir (path:string) hash itemPath: Result<VerificationResult, string> =
+            if actualHash = expectedHash then
+                Ok(VerificationResult.Matches(path, actualHash))
+            else
+                Ok(VerificationResult.Differs(path, expectedHash, actualHash))
+
+    let verifyHashAndItemByGuessing
+        (progressObserver: IObserver<HashingUpdate>)
+        (hashType: Checksum.HashType option)
+        includeHiddenFiles
+        includeEmptyDir
+        (path: string)
+        hash
+        itemPath
+        : Result<VerificationResult, string> =
 
         let basePath = Path.GetDirectoryName path
 
         match hashType with
         | Some t ->
             // Use specified hashType
-            verifyHashAndItem progressObserver t includeHiddenFiles includeEmptyDir basePath hash itemPath
+            verifyHashAndItem
+                progressObserver
+                t
+                includeHiddenFiles
+                includeEmptyDir
+                basePath
+                hash
+                itemPath
         | None ->
             // Try to guess the hashtype based on hash length
             let matchedHashType =
                 hashLengths
-                |> Array.filter(fun (_, len) -> len = hash.Length)
+                |> Array.filter (fun (_, len) -> len = hash.Length)
                 |> Array.map (fun (t, _) -> t)
+
             if matchedHashType.Length = 1 then
                 // Only one HashType matches the hash lengths.
-                verifyHashAndItem progressObserver matchedHashType.[0] includeHiddenFiles includeEmptyDir basePath hash itemPath
+                verifyHashAndItem
+                    progressObserver
+                    matchedHashType.[0]
+                    includeHiddenFiles
+                    includeEmptyDir
+                    basePath
+                    hash
+                    itemPath
             else
                 // Try to determine HashType based on file extension.
-                let m = Regex.Match(path, "\.([a-zA-Z0-9]+?).txt");
+                let m = Regex.Match(path, "\.([a-zA-Z0-9]+?).txt")
+
                 if m.Success then
                     let fileGuess = Checksum.parseHashType m.Groups[1].Value
-                    verifyHashAndItem progressObserver fileGuess.Value includeHiddenFiles includeEmptyDir basePath hash itemPath
+
+                    verifyHashAndItem
+                        progressObserver
+                        fileGuess.Value
+                        includeHiddenFiles
+                        includeEmptyDir
+                        basePath
+                        hash
+                        itemPath
                 else
                     Error("Cannot determine which hash algorithm to use")
 
 
-    let verifyHashFile (progressObserver: IObserver<HashingUpdate>) (hashType: Checksum.HashType option)
+    let verifyHashFile
+        (progressObserver: IObserver<HashingUpdate>)
+        (hashType: Checksum.HashType option)
         includeHiddenFiles
         includeEmptyDir
-        origPath =
+        origPath
+        =
 
-        let verifyValidHashFile (path:string) =
+        let verifyValidHashFile (path: string) =
             let baseDirPath = Path.GetDirectoryName path
 
-            let isTopLevelItem (line:string): bool =
+            let isTopLevelItem (line: string) : bool =
                 match line with
                 | txt when txt.StartsWith(Common.bSpacer) -> false
                 | txt when txt.StartsWith(Common.iSpacer) -> false
@@ -105,7 +156,7 @@ module Verification =
                 | txt when txt.StartsWith(Common.lSpacer) -> false
                 | _ -> true
 
-            let getHashAndItem (line:string) =
+            let getHashAndItem (line: string) =
                 let pieces = line.Split "  "
                 assert (pieces.Length = 2)
                 (pieces.[0], pieces.[1])
@@ -128,12 +179,13 @@ module Verification =
                         path
                         hash
                         itemPath)
+
             allVerificationResults
 
         async {
             return
                 if File.Exists(origPath) then
-                    Ok (verifyValidHashFile origPath)
+                    Ok(verifyValidHashFile origPath)
                 else
                     Error(sprintf "'%s' is not a valid hash file" origPath)
         }
@@ -142,17 +194,18 @@ module Verification =
     let printVerificationResults
         verbosity
         colorize
-        (result : Result<VerificationResult,string>) =
+        (result: Result<VerificationResult, string>)
+        =
 
         let printSuccess path hash =
             match verbosity with
-                | Quiet -> ()
-                | Normal ->
-                    Util.printColor colorize ConsoleColor.Green "MATCHES"
-                    printfn "%s%s" Common.bSpacer path
-                | Detailed ->
-                    Util.printColor colorize ConsoleColor.Green "MATCHES"
-                    printfn "%s%s (%s)" Common.bSpacer path hash
+            | Quiet -> ()
+            | Normal ->
+                Util.printColor colorize ConsoleColor.Green "MATCHES"
+                printfn "%s%s" Common.bSpacer path
+            | Detailed ->
+                Util.printColor colorize ConsoleColor.Green "MATCHES"
+                printfn "%s%s (%s)" Common.bSpacer path hash
 
         let printDiffer path actualHash expectedHash =
             match verbosity with
@@ -162,7 +215,13 @@ module Verification =
                 printfn "%s%s" Common.bSpacer path
             | Detailed ->
                 Util.printColor colorize ConsoleColor.DarkYellow "DIFFERS"
-                printfn "%s%s (%s, expected: %s)" Common.bSpacer path actualHash expectedHash
+
+                printfn
+                    "%s%s (%s, expected: %s)"
+                    Common.bSpacer
+                    path
+                    actualHash
+                    expectedHash
 
         let printError path =
             match verbosity with
@@ -176,4 +235,5 @@ module Verification =
         | Ok verificationResult ->
             match verificationResult with
             | Matches(path, hash) -> printSuccess path hash
-            | Differs(path, expectedHash, actualHash) -> printDiffer path actualHash expectedHash
+            | Differs(path, expectedHash, actualHash) ->
+                printDiffer path actualHash expectedHash

--- a/src/HashUtil/Verification.fs
+++ b/src/HashUtil/Verification.fs
@@ -47,6 +47,7 @@ module Verification =
     let verifyHashAndItem
         (progressObserver: IObserver<HashingUpdate>)
         (hashType: Checksum.HashType)
+        (ignorePatterns: string[])
         includeHiddenFiles
         includeEmptyDir
         basePath
@@ -64,10 +65,10 @@ module Verification =
             <| Hashing.makeHashStructureObservable
                 progressObserver
                 hashType
-                [||] // TODO: fix later
+                ignorePatterns
                 includeHiddenFiles
                 includeEmptyDir
-                fullPath // TODO: fix later with root dir
+                fullPath
                 fullPath
 
         match itemHashResult with
@@ -83,6 +84,7 @@ module Verification =
     let verifyHashAndItemByGuessing
         (progressObserver: IObserver<HashingUpdate>)
         (hashType: Checksum.HashType option)
+        (ignorePatterns: string[])
         includeHiddenFiles
         includeEmptyDir
         (path: string)
@@ -98,6 +100,7 @@ module Verification =
             verifyHashAndItem
                 progressObserver
                 t
+                ignorePatterns
                 includeHiddenFiles
                 includeEmptyDir
                 basePath
@@ -115,6 +118,7 @@ module Verification =
                 verifyHashAndItem
                     progressObserver
                     matchedHashType.[0]
+                    ignorePatterns
                     includeHiddenFiles
                     includeEmptyDir
                     basePath
@@ -130,6 +134,7 @@ module Verification =
                     verifyHashAndItem
                         progressObserver
                         fileGuess.Value
+                        ignorePatterns
                         includeHiddenFiles
                         includeEmptyDir
                         basePath
@@ -142,14 +147,13 @@ module Verification =
     let verifyHashFile
         (progressObserver: IObserver<HashingUpdate>)
         (hashType: Checksum.HashType option)
+        (ignorePatterns: string[])
         includeHiddenFiles
         includeEmptyDir
         origPath
         =
 
         let verifyValidHashFile (path: string) =
-            let baseDirPath = Path.GetDirectoryName path
-
             let isTopLevelItem (line: string) : bool =
                 match line with
                 | txt when txt.StartsWith(Common.bSpacer) -> false
@@ -176,6 +180,7 @@ module Verification =
                     verifyHashAndItemByGuessing
                         progressObserver
                         hashType
+                        ignorePatterns
                         includeHiddenFiles
                         includeEmptyDir
                         path

--- a/src/HashUtil/Verification.fs
+++ b/src/HashUtil/Verification.fs
@@ -67,7 +67,7 @@ module Verification =
                 [||] // TODO: fix later
                 includeHiddenFiles
                 includeEmptyDir
-                "" // TODO: fix later with root dir
+                fullPath // TODO: fix later with root dir
                 fullPath
 
         match itemHashResult with

--- a/src/make_release.fsx
+++ b/src/make_release.fsx
@@ -1,6 +1,7 @@
 #!/usr/bin/env dotnet fsi
 
 #r "System.IO.Compression.FileSystem.dll"
+#r "System.Security.Cryptography.dll"
 #load "HashUtil/Util.fs"
 
 open System
@@ -137,7 +138,7 @@ let buildSingleBinary (profile: PublishSpec) =
         sprintf "%s_%s" nameAndVersion profile.Name
 
     let oldProfileDir =
-        "src/App/bin/Release/net6.0/publish/binary"
+        "src/App/bin/Release/net7.0/publish/binary"
 
     let newProfileDir = Path.Combine(releaseDir, releaseName)
 
@@ -166,7 +167,7 @@ let makeNuGetRelease () =
 let makeDotnetRelease () =
     dotnet "publish -c Release -p:PublishProfile=dotnet src/App/App.fsproj"
     let releaseName = sprintf "%s_dotnet" nameAndVersion
-    Directory.Move("src/App/bin/Release/net6.0/publish/dotnet", Path.Combine(releaseDir, releaseName))
+    Directory.Move("src/App/bin/Release/net7.0/publish/dotnet", Path.Combine(releaseDir, releaseName))
     compressDir Zip releaseName
     compressDir TarGz releaseName
 

--- a/src/make_release.fsx
+++ b/src/make_release.fsx
@@ -12,7 +12,7 @@ open System.Security.Cryptography
 open HashUtil.Util
 
 // Configuration ----------------------------------------------------
-let versionStr = "1.2.0"
+let versionStr = "1.3.0"
 // ------------------------------------------------------------------
 
 let releaseDir = "release"


### PR DESCRIPTION
Fixes #20 

Added a new `--ignore` flag to specify directories and files to ignore.

Example:
`hashdir --ignore "node_modules" --ignore "**/*.xml" ~/Desktop/project`