### PR TITLE
Add link to AUR package in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ There are several ways to get hashdir. Full details can be found [here](https://
 - **Homebrew\***: `brew install ultimateanu/software/hashdir`
 - **dotnet**: `dotnet tool install --global hashdir`
 - **Stand-alone binary**: latest version for macOS, Windows, and Linux can be found at [releases](https://github.com/ultimateanu/hashdir/releases)
+- **AUR (Arch User Repository)**: If you are using an Arch-based distribution, you can build and install the [hashdir](https://aur.archlinux.org/packages/hashdir) package from the AUR
 
 \*_Homebrew currently requires a project to have 50 stars to be included in core. So I’ve set up a custom tap for now that still allows easy installation. If you like this project, please consider starring on Github and adding a formula to Homebrew core eventually._
 


### PR DESCRIPTION
Hi, thanks for hashdir!

I've made a package on the Arch User Repository for hashdir, which allows users of Arch Linux and other Linux distributions based on Arch to build and install hashdir easily.

https://aur.archlinux.org/packages/hashdir

The PKGBUILD, which is a script that defines how to build the package, can be viewed here: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=hashdir

My computers are all x86_64, but I have tried to enable the package to be built on aarch64. This is untested at the moment.

This pull request updates the README to include a link to the AUR package. Feel free to change the language, or to not include it in the README at all. Also if at some point in the future, you'd like to be the maintainer of the AUR package, just let me know :+1: 

Thanks!